### PR TITLE
Optional append domain name to username

### DIFF
--- a/ImapAuthenticationProvider.php
+++ b/ImapAuthenticationProvider.php
@@ -198,6 +198,7 @@ class ImapAuthenticationProvider extends AbstractPrimaryAuthenticationProvider  
             global $wgImapAuthorizationImapServerEnforceSsl;
             global $wgImapAuthorizationImapServerEnforceTls;
             global $wgImapAuthorizationImapServerVerifyCert;
+            global $wgImapAuthorizationAppendDomain;
 
             $connstr = '{' . $wgImapAuthorizationImapServerAddress . ':' . $wgImapAuthorizationImapServerPort . '}/imap';
             if ($wgImapAuthorizationImapServerEnforceSsl) {
@@ -211,9 +212,15 @@ class ImapAuthenticationProvider extends AbstractPrimaryAuthenticationProvider  
             } else {
                 $connstr .= '/novalidate-cert';
             }
+            
+            if ($wgImapAuthorizationAppendDomain) {
+			    $imap_username = $username.'@'.$wgImapAuthorizationAppendDomain;
+			} else {
+			    $imap_username = $username;
+			}
 
             // Opening the IMAP connection
-            $mbox = imap_open($connstr, $username, $req->password, OP_HALFOPEN);
+            $mbox = imap_open($connstr, $imap_username, $req->password, OP_HALFOPEN);
             if ($mbox === false) {
                 return AuthenticationResponse::newAbstain();
             } else {

--- a/ImapAuthenticationProvider.php
+++ b/ImapAuthenticationProvider.php
@@ -214,10 +214,10 @@ class ImapAuthenticationProvider extends AbstractPrimaryAuthenticationProvider  
             }
             
             if ($wgImapAuthorizationAppendDomain) {
-			    $imap_username = $username.'@'.$wgImapAuthorizationAppendDomain;
-			} else {
-			    $imap_username = $username;
-			}
+	    	$imap_username = $username.'@'.$wgImapAuthorizationAppendDomain;
+	    } else {
+		$imap_username = $username;
+	    }
 
             // Opening the IMAP connection
             $mbox = imap_open($connstr, $imap_username, $req->password, OP_HALFOPEN);


### PR DESCRIPTION
Optional append domain name to username, to be able to use email-addresses as IMAP usernames.